### PR TITLE
typo: rename HEALTH_TOKEN to HEALTH_CHECK_TOKEN

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Zephyr Central Server
 
-[![License](https://img.shields.io/github/license/saluki/nestjs-template.svg)](https://github.com/saluki/nestjs-template/blob/master/LICENSE)
-
 - Crafted for Docker environments (Dockerfile support and environment variables)
 - REST API with [Prisma](https://www.prisma.io/) support
 - Swagger documentation, [Joi](https://github.com/hapijs/joi) validation, Winston logger, ...
@@ -130,7 +128,7 @@ A healthcheck API is a REST endpoint that can be used to validate the status of 
 The healthcheck API endpoint internally triggers an overall health check of the service. This can include database
 connection checks, system properties, disk availability and memory availability.
 
-The example healthcheck endpoint can be request with the token located in the `HEALTH_TOKEN` environment variable.
+The example healthcheck endpoint can be request with the token located in the `HEALTH_CHECK_TOKEN` environment variable.
 
 ```sh
 curl -H 'Authorization: Bearer ThisMustBeChanged' http://localhost:3000/api/v1/health

--- a/src/modules/common/model/config.ts
+++ b/src/modules/common/model/config.ts
@@ -10,7 +10,7 @@ export interface Config {
 
     readonly JWT_ISSUER: string;
 
-    readonly HEALTH_TOKEN: string;
+    readonly HEALTH_CHECK_TOKEN: string;
 
     readonly PASSENGERS_ALLOWED: string;
 

--- a/src/modules/common/provider/config.provider.ts
+++ b/src/modules/common/provider/config.provider.ts
@@ -15,7 +15,7 @@ export const configProvider = {
             SWAGGER_ENABLE: Joi.number().required(),
             JWT_SECRET: Joi.string().required(),
             JWT_ISSUER: Joi.string().required(),
-            HEALTH_TOKEN: Joi.string().required(),
+            HEALTH_CHECK_TOKEN: Joi.string().required(),
             PASSENGERS_ALLOWED: Joi.string().valid('yes', 'no').required()
         });
 

--- a/src/modules/common/security/health.guard.ts
+++ b/src/modules/common/security/health.guard.ts
@@ -7,6 +7,6 @@ export class HealthGuard implements CanActivate {
     public canActivate(context: ExecutionContext): boolean {
 
         const request = context.switchToHttp().getRequest<FastifyRequest>();
-        return request.headers.authorization === `Bearer ${process.env.HEALTH_TOKEN}`;
+        return request.headers.authorization === `Bearer ${process.env.HEALTH_CHECK_TOKEN}`;
     }
 }


### PR DESCRIPTION
This pull request includes changes to standardize the naming of the health token across various files in the codebase. The most important changes include renaming the health token in the configuration interface, updating the configuration provider to use the new name, and modifying the health guard to check for the updated token name.

Changes to standardize health token naming:

* [`src/modules/common/model/config.ts`](diffhunk://#diff-13006541509cb4ecd56930c087d09ed2349b4498cfd935a21546092a297137e9L13-R13): Renamed `HEALTH_TOKEN` to `HEALTH_CHECK_TOKEN` in the `Config` interface.
* [`src/modules/common/provider/config.provider.ts`](diffhunk://#diff-5fed3715e2c05c6e38e5753f2aa7a088c277cfc4826cd58628ee4e8620bf2d98L18-R18): Updated the configuration provider to require `HEALTH_CHECK_TOKEN` instead of `HEALTH_TOKEN`.
* [`src/modules/common/security/health.guard.ts`](diffhunk://#diff-c83d28aa03664b7afd508662a0e66f665fcdd035a8fc05a9c363599d14215b63L10-R10): Modified the `HealthGuard` class to check for `HEALTH_CHECK_TOKEN` in the request headers.