### PR TITLE
feat: dependabot and merge dev

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "npm" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/auto_approve.yaml
+++ b/.github/workflows/auto_approve.yaml
@@ -1,0 +1,13 @@
+name: Auto approve
+
+on: pull_request_target
+
+jobs:
+  auto-approve:
+    if: github.actor == 'dependabot[bot]' || github.actor == 'renovate[bot]' || github.actor == 'binaryYuki'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: hmarr/auto-approve-action@v4
+        with:
+          github-token: ${{ secrets.GH_TOKEN }}
+          review-message: "LGTM! 🚀"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Zephyr Central Server
 
-[![License](https://img.shields.io/github/license/saluki/nestjs-template.svg)](https://github.com/saluki/nestjs-template/blob/master/LICENSE)
-
 - Crafted for Docker environments (Dockerfile support and environment variables)
 - REST API with [Prisma](https://www.prisma.io/) support
 - Swagger documentation, [Joi](https://github.com/hapijs/joi) validation, Winston logger, ...
@@ -130,7 +128,7 @@ A healthcheck API is a REST endpoint that can be used to validate the status of 
 The healthcheck API endpoint internally triggers an overall health check of the service. This can include database
 connection checks, system properties, disk availability and memory availability.
 
-The example healthcheck endpoint can be request with the token located in the `HEALTH_TOKEN` environment variable.
+The example healthcheck endpoint can be request with the token located in the `HEALTH_CHECK_TOKEN` environment variable.
 
 ```sh
 curl -H 'Authorization: Bearer ThisMustBeChanged' http://localhost:3000/api/v1/health

--- a/src/modules/common/model/config.ts
+++ b/src/modules/common/model/config.ts
@@ -10,7 +10,7 @@ export interface Config {
 
     readonly JWT_ISSUER: string;
 
-    readonly HEALTH_TOKEN: string;
+    readonly HEALTH_CHECK_TOKEN: string;
 
     readonly PASSENGERS_ALLOWED: string;
 

--- a/src/modules/common/provider/config.provider.ts
+++ b/src/modules/common/provider/config.provider.ts
@@ -15,7 +15,7 @@ export const configProvider = {
             SWAGGER_ENABLE: Joi.number().required(),
             JWT_SECRET: Joi.string().required(),
             JWT_ISSUER: Joi.string().required(),
-            HEALTH_TOKEN: Joi.string().required(),
+            HEALTH_CHECK_TOKEN: Joi.string().required(),
             PASSENGERS_ALLOWED: Joi.string().valid('yes', 'no').required()
         });
 

--- a/src/modules/common/security/health.guard.ts
+++ b/src/modules/common/security/health.guard.ts
@@ -7,6 +7,6 @@ export class HealthGuard implements CanActivate {
     public canActivate(context: ExecutionContext): boolean {
 
         const request = context.switchToHttp().getRequest<FastifyRequest>();
-        return request.headers.authorization === `Bearer ${process.env.HEALTH_TOKEN}`;
+        return request.headers.authorization === `Bearer ${process.env.HEALTH_CHECK_TOKEN}`;
     }
 }


### PR DESCRIPTION
This pull request includes several updates to the repository configuration and codebase, focusing on Dependabot integration, auto-approval workflow, and renaming a configuration token.

### Configuration Updates:

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R1-R11): Added configuration for Dependabot to automate version updates for npm packages on a weekly schedule.
* [`.github/workflows/auto_approve.yaml`](diffhunk://#diff-c6a36812d975928c913e1d4ab450cc274a448e0b6ca5bedd9486ef3df3013e19R1-R13): Introduced an auto-approval workflow for pull requests created by Dependabot, Renovate, or a specific user.

### Codebase Changes:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L133-R131): Updated references to the health check token environment variable from `HEALTH_TOKEN` to `HEALTH_CHECK_TOKEN`.
* [`src/modules/common/model/config.ts`](diffhunk://#diff-13006541509cb4ecd56930c087d09ed2349b4498cfd935a21546092a297137e9L13-R13): Renamed the `HEALTH_TOKEN` configuration property to `HEALTH_CHECK_TOKEN`.
* [`src/modules/common/provider/config.provider.ts`](diffhunk://#diff-5fed3715e2c05c6e38e5753f2aa7a088c277cfc4826cd58628ee4e8620bf2d98L18-R18): Updated the Joi validation schema to reflect the new `HEALTH_CHECK_TOKEN` property name.
* [`src/modules/common/security/health.guard.ts`](diffhunk://#diff-c83d28aa03664b7afd508662a0e66f665fcdd035a8fc05a9c363599d14215b63L10-R10): Modified the authorization check to use the renamed `HEALTH_CHECK_TOKEN` environment variable.