### PR TITLE
change sh to zsh

### DIFF
--- a/gradlew
+++ b/gradlew
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/zsh
 
 #
 # Copyright © 2015-2021 the original authors.


### PR DESCRIPTION
This pull request includes a small change to the `gradlew` file. The change updates the script's shebang line to use `zsh` instead of `sh`.