### PR TITLE
chore: fix missing author

### DIFF
--- a/src/main/java/Zephyr/entities/Service.java
+++ b/src/main/java/Zephyr/entities/Service.java
@@ -12,7 +12,7 @@ import jakarta.persistence.*;
  * The name and status fields are required.
  * The description field is optional.
  *
- * Author: binaryYuki
+ * @author binaryYuki
  */
 @Entity
 @Table(name = "services")


### PR DESCRIPTION
This pull request includes a small change to the `Service.java` file. The change corrects the author tag annotation to use the proper Javadoc format.

* [`src/main/java/Zephyr/entities/Service.java`](diffhunk://#diff-31425b461bb93e94643a4141dee10a0c0b7b18c0a03f60a84f64d274ecf04013L15-R15): Changed the author tag from `Author:` to `@author` to follow the correct Javadoc annotation format.