### PR TITLE
ci: bump ubuntu-22.04

### DIFF
--- a/.github/workflows/auto_sync.yaml
+++ b/.github/workflows/auto_sync.yaml
@@ -13,7 +13,7 @@ on:
 jobs:
   sync_latest_from_upstream:
     name: Sync latest commits from upstream repo
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: ${{ github.event.repository.fork }}
 
     steps:


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/auto_sync.yaml` file. The change updates the `runs-on` parameter to use `ubuntu-22.04` instead of `ubuntu-latest`.

* [`.github/workflows/auto_sync.yaml`](diffhunk://#diff-b63d931be66c329a9aea06a134159e8db4ba4c0597ca622c7a6587f96185ec9dL16-R16): Updated the `runs-on` parameter to use `ubuntu-22.04`.